### PR TITLE
feat: BL-14884 Added API usage key to the mock API

### DIFF
--- a/Postman/Recalls.postman_collection.json
+++ b/Postman/Recalls.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "af7e7888-8f54-40fb-a0b8-c8f91fdd45a7",
+		"_postman_id": "c7574902-1f0b-4110-ae64-3e0649304eaa",
 		"name": "Recalls",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "8553673"
@@ -29,7 +29,13 @@
 					],
 					"request": {
 						"method": "POST",
-						"header": [],
+						"header": [
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
+								"type": "text"
+							}
+						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n  \"vin\": \"ABCD122CBAD11435\",\n  \"manufacturerCampaignReference\": \"string\",\n  \"dvsaCampaignReference\": \"R/2013/121\",\n  \"recallCampaignStartDate\": \"2022-01-31\"\n}"
@@ -76,6 +82,11 @@
 							{
 								"key": "Authorization",
 								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
 								"type": "text"
 							}
 						],
@@ -126,6 +137,11 @@
 								"key": "Authorization",
 								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
+								"type": "text"
 							}
 						],
 						"body": {
@@ -175,11 +191,65 @@
 								"key": "Authorization",
 								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
+								"type": "text"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n  \"vin\": \"string\",\n  \"manufacturerCampaignReference\": \"string\",\n  \"dvsaCampaignReference\": \"R/2013/121\",\n  \"recallCampaignStartDate\": \"12-a2332\"\n}"
+						},
+						"url": {
+							"raw": "http://127.0.0.1:3000/recalls/",
+							"protocol": "http",
+							"host": [
+								"127",
+								"0",
+								"0",
+								"1"
+							],
+							"port": "3000",
+							"path": [
+								"recalls",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create a new Recall - fail no usage key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 403\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									"pm.test(\"Body matches string\", function () {",
+									"    pm.expect(pm.response.text()).to.include(\"Forbidden\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"vin\": \"ABCD122CBAD11435\",\n  \"manufacturerCampaignReference\": \"string\",\n  \"dvsaCampaignReference\": \"R/2013/121\",\n  \"recallCampaignStartDate\": \"2022-01-31\"\n}"
 						},
 						"url": {
 							"raw": "http://127.0.0.1:3000/recalls/",
@@ -220,6 +290,11 @@
 							{
 								"key": "Authorization",
 								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
 								"type": "text"
 							}
 						],
@@ -273,6 +348,11 @@
 								"key": "Authorization",
 								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 								"type": "default"
+							},
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
+								"type": "text"
 							}
 						],
 						"body": {
@@ -331,6 +411,11 @@
 								"key": "Authorization",
 								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 								"type": "default"
+							},
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
+								"type": "text"
 							}
 						],
 						"body": {
@@ -392,6 +477,11 @@
 								"key": "Authorization",
 								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 								"type": "default"
+							},
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
+								"type": "text"
 							}
 						],
 						"body": {
@@ -447,6 +537,11 @@
 								"key": "Authorization",
 								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 								"type": "default"
+							},
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
+								"type": "text"
 							}
 						],
 						"body": {
@@ -505,6 +600,11 @@
 								"key": "Authorization",
 								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 								"type": "default"
+							},
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
+								"type": "text"
 							}
 						],
 						"body": {
@@ -566,6 +666,11 @@
 								"key": "Authorization",
 								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 								"type": "default"
+							},
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
+								"type": "text"
 							}
 						],
 						"body": {
@@ -621,6 +726,11 @@
 								"key": "Authorization",
 								"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 								"type": "default"
+							},
+							{
+								"key": "x-api-key",
+								"value": "theprovidedapiusagekey",
+								"type": "text"
 							}
 						],
 						"body": {
@@ -749,6 +859,11 @@
 						"key": "Authorization",
 						"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "theprovidedapiusagekey",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -795,6 +910,11 @@
 						"key": "Authorization",
 						"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 						"type": "default"
+					},
+					{
+						"key": "x-api-key",
+						"value": "theprovidedapiusagekey",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -856,6 +976,11 @@
 						"key": "Authorization",
 						"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "theprovidedapiusagekey",
+						"type": "text"
 					}
 				],
 				"url": {
@@ -908,6 +1033,11 @@
 						"key": "Authorization",
 						"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "theprovidedapiusagekey",
+						"type": "text"
 					}
 				],
 				"url": {
@@ -951,6 +1081,11 @@
 						"key": "Authorization",
 						"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 						"type": "default"
+					},
+					{
+						"key": "x-api-key",
+						"value": "theprovidedapiusagekey",
+						"type": "text"
 					}
 				],
 				"body": {

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ To run the recalls mock api locally, you will need to use Postman to send reques
 
 ## Sample Calls
 
+### API Usage Key
+An API Usage Key will be provided to you when you register for the service, this must be provided in the x-api-key header with every request.
+
 ### Authentication
  make a post request to http://127.0.0.1:3000/oauth2/v2.0/token
  
@@ -47,6 +50,7 @@ To run the recalls mock api locally, you will need to use Postman to send reques
  header:
  ```json
   "Authorization": "insert bearer token",
+  "x-api-key": "insert usage key"
 ```
  body:
  ```json
@@ -63,6 +67,7 @@ To run the recalls mock api locally, you will need to use Postman to send reques
  header:
  ```json
   "Authorization": "insert bearer token",
+  "x-api-key": "insert usage key"
 ```
  body:
  ```json
@@ -78,6 +83,7 @@ To run the recalls mock api locally, you will need to use Postman to send reques
  header:
  ```json
   "Authorization": "insert bearer token",
+  "x-api-key": "insert usage key"
 ```
 
 ### Delete a recall
@@ -87,6 +93,7 @@ To run the recalls mock api locally, you will need to use Postman to send reques
  header:
  ```json
   "Authorization": "insert bearer token",
+  "x-api-key": "insert usage key"
 ```
 
 ## Directories

--- a/src/handler/delete.ts
+++ b/src/handler/delete.ts
@@ -7,11 +7,15 @@ import validAuthorisation from '../util/authorisation';
 import Vehicles from '../util/vehicles';
 import { alreadyRepaired } from '../util/validatorsRecall';
 import logger from '../util/logger';
+import validUsageKey from '../util/apiUsageKey';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   if (!validAuthorisation(event.headers)) {
     return HttpResponse(StatusCodes.UNAUTHORIZED, getReasonPhrase(StatusCodes.UNAUTHORIZED));
+  }
+  if (!validUsageKey(event.headers)) {
+    return HttpResponse(StatusCodes.FORBIDDEN, getReasonPhrase(StatusCodes.FORBIDDEN));
   }
   if (!event.queryStringParameters) {
     return HttpResponse(StatusCodes.BAD_REQUEST, ExternalApiErrorMessages.DvsaAndManufacturerCampaignReferenceMissing);

--- a/src/handler/get.ts
+++ b/src/handler/get.ts
@@ -5,11 +5,15 @@ import HttpResponse from '../util/httpResponse';
 import validAuthorisation from '../util/authorisation';
 import Vehicles from '../util/vehicles';
 import { RecallResponseContract, RecallsDataReponseDetail, RecallsDataResponse } from '../util/payloads';
+import validUsageKey from '../util/apiUsageKey';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   if (!validAuthorisation(event.headers)) {
     return HttpResponse(StatusCodes.UNAUTHORIZED, getReasonPhrase(StatusCodes.UNAUTHORIZED));
+  }
+  if (!validUsageKey(event.headers)) {
+    return HttpResponse(StatusCodes.FORBIDDEN, getReasonPhrase(StatusCodes.FORBIDDEN));
   }
   if (!event.pathParameters) {
     return HttpResponse(StatusCodes.NOT_FOUND, getReasonPhrase(StatusCodes.NOT_FOUND));

--- a/src/handler/post.ts
+++ b/src/handler/post.ts
@@ -7,11 +7,15 @@ import { validDvsaCampaignReference, allRequiredFieldsCreateRecall, validDateFor
 import validAuthorisation from '../util/authorisation';
 import Vehicles from '../util/vehicles';
 import ExternalApiErrorMessages from '../util/externalApiReferences';
+import validUsageKey from '../util/apiUsageKey';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   if (!validAuthorisation(event.headers)) {
     return HttpResponse(StatusCodes.UNAUTHORIZED, getReasonPhrase(StatusCodes.UNAUTHORIZED));
+  }
+  if (!validUsageKey(event.headers)) {
+    return HttpResponse(StatusCodes.FORBIDDEN, getReasonPhrase(StatusCodes.FORBIDDEN));
   }
   if (!event.body) {
     return HttpResponse(StatusCodes.BAD_REQUEST, ExternalApiErrorMessages.InvalidRequestBody);

--- a/src/handler/put.ts
+++ b/src/handler/put.ts
@@ -8,11 +8,15 @@ import Vehicles from '../util/vehicles';
 import { RecallsUpdateRequest } from '../util/payloads';
 import { allRequiredFieldsUpdateRecall, alreadyRepaired, validDateFormat } from '../util/validatorsRecall';
 import logger from '../util/logger';
+import validUsageKey from '../util/apiUsageKey';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   if (!validAuthorisation(event.headers)) {
     return HttpResponse(StatusCodes.UNAUTHORIZED, getReasonPhrase(StatusCodes.UNAUTHORIZED));
+  }
+  if (!validUsageKey(event.headers)) {
+    return HttpResponse(StatusCodes.FORBIDDEN, getReasonPhrase(StatusCodes.FORBIDDEN));
   }
   if (!event.body) {
     return HttpResponse(StatusCodes.BAD_REQUEST, ExternalApiErrorMessages.InvalidRequestBody);

--- a/src/util/apiUsageKey.ts
+++ b/src/util/apiUsageKey.ts
@@ -1,0 +1,15 @@
+import { APIGatewayProxyEventHeaders } from 'aws-lambda';
+
+const usageTokenRegex = new RegExp(/^.{10,}$/g);
+
+const validUsageKey = (headers:APIGatewayProxyEventHeaders):boolean => {
+  if (headers['X-Api-Key']) {
+    if (usageTokenRegex.test(headers['X-Api-Key'])) {
+      return true;
+    }
+    return false;
+  }
+  return false;
+};
+
+export default validUsageKey;

--- a/src/util/apiUsageKey.ts
+++ b/src/util/apiUsageKey.ts
@@ -3,13 +3,7 @@ import { APIGatewayProxyEventHeaders } from 'aws-lambda';
 const usageTokenRegex = new RegExp(/^.{10,}$/g);
 
 const validUsageKey = (headers:APIGatewayProxyEventHeaders):boolean => {
-  if (headers['X-Api-Key']) {
-    if (usageTokenRegex.test(headers['X-Api-Key'])) {
-      return true;
-    }
-    return false;
-  }
-  return false;
+  return headers['X-Api-Key'] != null && usageTokenRegex.test(headers['X-Api-Key']);
 };
 
 export default validUsageKey;

--- a/src/util/authorisation.ts
+++ b/src/util/authorisation.ts
@@ -3,13 +3,7 @@ import { APIGatewayProxyEventHeaders } from 'aws-lambda';
 const tokenRegex = new RegExp(/^Bearer\s.{12,}/g);
 
 const validAuthorisation = (headers:APIGatewayProxyEventHeaders):boolean => {
-  if (headers.Authorization) {
-    if (tokenRegex.test(headers.Authorization)) {
-      return true;
-    }
-    return false;
-  }
-  return false;
+  return headers.Authorization != null && tokenRegex.test(headers.Authorization) ;
 };
 
 export default validAuthorisation;

--- a/tests/handler/post.test.ts
+++ b/tests/handler/post.test.ts
@@ -15,7 +15,7 @@ describe('Test Post Lambda Function', () => {
       recallCampaignStartDate: '2022-01-31',
     };
     const requestContext: APIGatewayEventRequestContext = <APIGatewayEventRequestContext> { requestId: v4() };
-    const headers: Record<string, string> = { Authorization: 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ij' };
+    const headers: Record<string, string> = { Authorization: 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ij', 'X-Api-Key' : 'theprovidedapiusagekey' };
     const eventMock: APIGatewayProxyEvent = <APIGatewayProxyEvent> {
       body: JSON.stringify(body),
       requestContext,


### PR DESCRIPTION
## Description

Recalls Mock API updated to require both an API key and access token in the header of each request.
The README updated to include the requirement for an API key.
The Postman collection has been updated to reflect changes.

Related issue: [BL-14884](https://dvsa.atlassian.net/browse/BL-14884)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works